### PR TITLE
Add preliminary support for django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TOXENV='docs'
   - TOXENV='pep8'
   - TOXENV='isort'
+  - DJANGO='django30' CMS='cmsno'
   - DJANGO='django22' CMS='cmsno'
   - DJANGO='django22' CMS='cms37'
   - DJANGO='django21' CMS='cmsno'
@@ -86,6 +87,10 @@ matrix:
   - python: 3.5
     env: DJANGO='django111' CMS='cms34'
 
+  - python: 2.7
+    env: DJANGO='django30' CMS='cms37'
+  - python: 2.7
+    env: DJANGO='django30' CMS='cmsno'
   - python: 2.7
     env: DJANGO='django22' CMS='cms37'
   - python: 2.7

--- a/app_helper/base_test.py
+++ b/app_helper/base_test.py
@@ -12,7 +12,7 @@ from django.core.handlers.base import BaseHandler
 from django.http import SimpleCookie
 from django.test import RequestFactory, TestCase, TransactionTestCase
 from django.utils.functional import SimpleLazyObject
-from django.utils.six import StringIO
+from six import StringIO
 
 from .utils import UserLoginContext, create_user, get_user_model, reload_urls, temp_dir
 

--- a/app_helper/main.py
+++ b/app_helper/main.py
@@ -9,8 +9,8 @@ import warnings
 
 from django.utils import autoreload
 from django.utils.encoding import force_text
-from six import text_type
 from docopt import DocoptExit, docopt
+from six import text_type
 
 from . import __version__
 from .utils import (

--- a/app_helper/main.py
+++ b/app_helper/main.py
@@ -9,7 +9,7 @@ import warnings
 
 from django.utils import autoreload
 from django.utils.encoding import force_text
-from django.utils.six import text_type
+from six import text_type
 from docopt import DocoptExit, docopt
 
 from . import __version__

--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -9,9 +9,9 @@ from distutils.version import LooseVersion
 from tempfile import mkdtemp
 
 import django
+import six
 from django.core.management import call_command
 from django.urls import clear_url_caches
-import six
 from django.utils.functional import empty
 
 from . import HELPER_FILE

--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -11,10 +11,8 @@ from tempfile import mkdtemp
 import django
 from django.core.management import call_command
 from django.urls import clear_url_caches
-from django.utils import six
+import six
 from django.utils.functional import empty
-from django.utils.six import StringIO
-from django.utils.six.moves import reload_module
 
 from . import HELPER_FILE
 
@@ -27,6 +25,10 @@ except ImportError:
 try:
     import cms  # NOQA
     CMS = True
+    CMS_40 = LooseVersion('4.0') <= LooseVersion(cms.__version__) < LooseVersion('4.1')
+    CMS_38 = LooseVersion('3.8') <= LooseVersion(cms.__version__) < LooseVersion('3.9')
+    CMS_37 = LooseVersion('3.7') <= LooseVersion(cms.__version__) < LooseVersion('3.8')
+    CMS_36 = LooseVersion('3.6') <= LooseVersion(cms.__version__) < LooseVersion('3.7')
     CMS_35 = LooseVersion('3.5') <= LooseVersion(cms.__version__) < LooseVersion('3.6')
     CMS_34 = LooseVersion('3.4') <= LooseVersion(cms.__version__) < LooseVersion('3.5')
     CMS_33 = LooseVersion('3.3') <= LooseVersion(cms.__version__) < LooseVersion('3.4')
@@ -35,6 +37,10 @@ try:
     CMS_30 = LooseVersion('3.0') <= LooseVersion(cms.__version__) < LooseVersion('3.1')
 except ImportError:  # pragma: no cover
     CMS = False
+    CMS_40 = False
+    CMS_38 = False
+    CMS_37 = False
+    CMS_36 = False
     CMS_35 = False
     CMS_34 = False
     CMS_33 = False
@@ -53,6 +59,9 @@ DJANGO_1_11 = LooseVersion(django.get_version()) < LooseVersion('2.0')
 DJANGO_2_0 = LooseVersion(django.get_version()) < LooseVersion('2.1')
 DJANGO_2_1 = LooseVersion(django.get_version()) < LooseVersion('2.2')
 DJANGO_2_2 = LooseVersion(django.get_version()) < LooseVersion('3.0')
+DJANGO_3_0 = LooseVersion(django.get_version()) < LooseVersion('3.1')
+DJANGO_3_1 = LooseVersion(django.get_version()) < LooseVersion('3.2')
+DJANGO_3_2 = LooseVersion(django.get_version()) < LooseVersion('4.0')
 
 
 def load_from_file(module_path):
@@ -91,8 +100,8 @@ def work_in(dirname=None):
 
 @contextlib.contextmanager
 def captured_output():
-    with patch('sys.stdout', new_callable=StringIO) as out:
-        with patch('sys.stderr', new_callable=StringIO) as err:
+    with patch('sys.stdout', new_callable=six.StringIO) as out:
+        with patch('sys.stderr', new_callable=six.StringIO) as err:
             yield out, err
 
 
@@ -322,11 +331,11 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):
 
 def reload_urls(settings, urlconf=None, cms_apps=True):
     if 'cms.urls' in sys.modules:
-        reload_module(sys.modules['cms.urls'])
+        six.moves.reload_module(sys.modules['cms.urls'])
     if urlconf is None:
         urlconf = settings.ROOT_URLCONF
     if urlconf in sys.modules:
-        reload_module(sys.modules[urlconf])
+        six.moves.reload_module(sys.modules[urlconf])
     clear_url_caches()
     if cms_apps:
         from cms.appresolver import clear_app_resolvers, get_app_patterns

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ coveralls
 wheel
 tox>=1.8
 aldryn-boilerplates
-django-filer
+https://github.com/divio/django-filer/archive/develop.zip
+pyflakes<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
     django111: django-mptt>0.8,<1.0
     django111: easy-thumbnails>2.4,<2.6
     django111: django-polymorphic>2.0
+    django111: django-formtools>=2.0,<2.1
     django20: django>=2,<2.1
     django20: django-mptt>0.9,<1.0
     django20: easy-thumbnails>2.4,<2.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,docs,py{37,36,35}-django{22,21,20}-cms{37,no},py{37,36,35}-django{21,20}-cms{36},py{37,36,35,27}-django{111}-cms{no,37,36,35,34}
+envlist = pep8,isort,docs,py{37,36,35}-django{30}-cms{no},py{37,36,35}-django{22,21,20}-cms{37,no},py{37,36,35}-django{21,20}-cms{36},py{37,36,35,27}-django{111}-cms{no,37,36,35,34}
 skip_missing_interpreters = True
 
 [testenv]
@@ -20,6 +20,9 @@ deps=
     django22: django-mptt>0.9,<1.0
     django22: easy-thumbnails>2.4,<2.6
     django22: django-polymorphic>2.0
+    django30: django-mptt>0.9,<1.0
+    django30: easy-thumbnails>2.4,<2.9
+    django30: django-polymorphic>2.0
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     cms34: djangocms-text-ckeditor>=3.5
     cms34: html5lib<=0.9999999


### PR DESCRIPTION
This only includes non-django CMS features as django CMS is not compatible with django 3