### PR TITLE
Fix runserver autoreload with channels 2.4

### DIFF
--- a/app_helper/main.py
+++ b/app_helper/main.py
@@ -218,10 +218,9 @@ def static_analisys(application):
 
 def server(bind="127.0.0.1", port=8000, migrate_cmd=False, verbose=1):  # pragma: no cover
     try:
-        from channels.log import setup_logger
         from channels.management.commands import runserver
 
-        logger = setup_logger("django.channels", 1)
+        logger = None
         use_channels = True
     except ImportError:
         from django.contrib.staticfiles.management.commands import runserver

--- a/changes/157.bugfix
+++ b/changes/157.bugfix
@@ -1,0 +1,1 @@
+Fix runserver autoreload with channels 2.4

--- a/tox.ini
+++ b/tox.ini
@@ -158,13 +158,13 @@ use_parentheses = True
 
 [check-manifest]
 ignore =
-    .[a-z]*
+    .*
     *.ini
     *.toml
     *.txt
     *.yml
     app_helper/test_utils/AUTHORS
-    app_helper/test_utils/example1/locale*
-    changes*
-    docs*
+    app_helper/test_utils/example1/locale/**
+    changes/**
+    docs/**
     tasks.py


### PR DESCRIPTION
# Description

Remove imports no longer existing in channels 2.4

## References

Fix #157 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
