### PR TITLE
Allow extra arguments in PytestTestRunner.run_tests

### DIFF
--- a/app_helper/pytest_runner.py
+++ b/app_helper/pytest_runner.py
@@ -11,13 +11,16 @@ class PytestTestRunner:
         self.keepdb = keepdb
         self.extra_args = kwargs.pop("pytest_args", "")
 
-    def run_tests(self, test_labels):
+    def run_tests(self, test_labels, *args, **kwargs):
         """Run pytest and return the exitcode.
 
         It translates some of Django's test command option to pytest's.
         """
         import pytest
 
+        self.verbosity = kwargs.get("verbosity", self.verbosity)
+        self.failfast = kwargs.get("failfast", self.failfast)
+        self.keepdb = kwargs.get("keepdb", self.keepdb)
         argv = shlex.split(os.environ.get("PYTEST_ARGS", ""))
         if self.extra_args:
             argv.extend(shlex.split(self.extra_args))

--- a/changes/165.bugfix
+++ b/changes/165.bugfix
@@ -1,0 +1,1 @@
+Allow extra arguments in PytestTestRunner.run_tests


### PR DESCRIPTION
# Description

Add extra arguments to PytestTestRunner.run_tests

## References

Fix #165 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
