### PR TITLE
Add Django 3.1 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,33 @@ jobs:
   test:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
         python-version: [3.8, 3.7, 3.6, 3.5]
-        django: [30, 22]
+        django: [31, 30, 22]
         cms: [no, 37]
+        continue-on-error: [false]
+        exclude:
+          - python-version: 3.5
+            django: 30
+          - python-version: 3.5
+            django: 31
+          - django: 31
+            cms: 37
+        include:
+          - python-version: 3.8
+            django: 31
+            cms: 37
+            continue-on-error: true
+          - python-version: 3.7
+            django: 31
+            cms: 37
+            continue-on-error: true
+          - python-version: 3.6
+            django: 31
+            cms: 37
+            continue-on-error: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.7, 3.6, 3.5]
         django: [31, 30, 22]
-        cms: [no, 37]
+        cms: [no, 37, 38]
         continue-on-error: [false]
         exclude:
           - python-version: 3.5
@@ -20,19 +20,6 @@ jobs:
             django: 31
           - django: 31
             cms: 37
-        include:
-          - python-version: 3.8
-            django: 31
-            cms: 37
-            continue-on-error: true
-          - python-version: 3.7
-            django: 31
-            cms: 37
-            continue-on-error: true
-          - python-version: 3.6
-            django: 31
-            cms: 37
-            continue-on-error: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,11 @@ It supports both tests writted using Django ``TestCase`` and pytest ones
 Supported versions
 ==================
 
-Python: 3.5, 3.6, 3.7
+Python: 3.6, 3.7, 3.8
 
 Django: 2.2 - 3.1
 
-django CMS: 3.7
+django CMS: 3.7, 3.8
 
 Newer versions might work but are not tested yet.
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Supported versions
 
 Python: 3.5, 3.6, 3.7
 
-Django: 2.2 - 3.0
+Django: 2.2 - 3.1
 
 django CMS: 3.7
 

--- a/changes/196.feature
+++ b/changes/196.feature
@@ -1,0 +1,1 @@
+Add support for Django 3.1

--- a/changes/196.feature
+++ b/changes/196.feature
@@ -1,1 +1,1 @@
-Add support for Django 3.1
+Add support for Django 3.1 / django CMS 3.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,9 +6,7 @@ pep517
 invoke
 tox>=1.8
 aldryn-boilerplates
-https://github.com/divio/django-filer/archive/develop.zip
 pyflakes<2.1
 pytest
 pytest-django
-bump2version
-https://github.com/hawkowl/towncrier/archive/master.zip
+django-filer

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,9 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{38,37,36}-django{31,30}-cms{37,no}
-    py{38,37,36,35}-django{22}-cms{37,no}
+    py{38,37,36}-django{31}-cms{38,no}
+    py{38,37,36}-django{30}-cms{38,37,no}
+    py{38,37,36}-django{22}-cms{38,37,no}
 
 [testenv]
 commands = {env:COMMAND:python} helper.py {posargs}
@@ -17,8 +18,10 @@ deps=
     django22: django~=2.2.0
     django30: django~=3.0.0
     django31: django~=3.1.0
-    cms37: django-cms>=3.7,<3.8
-    cms37: djangocms-text-ckeditor>=3.6
+    cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
+    cms37: djangocms-text-ckeditor
+    cms38: https://github.com/divio/django-cms/archive/release/3.8.x.zip
+    cms38: djangocms-text-ckeditor>=4.0,<5.0
     -r{toxinidir}/requirements-test.txt
 passenv =
     COMMAND

--- a/tox.ini
+++ b/tox.ini
@@ -8,19 +8,16 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{38,37,36}-django{30}-cms{37,no}
+    py{38,37,36}-django{31,30}-cms{37,no}
     py{38,37,36,35}-django{22}-cms{37,no}
 
 [testenv]
 commands = {env:COMMAND:python} helper.py {posargs}
 deps=
-    django22: django-mptt>0.9,<1.0
-    django22: easy-thumbnails>2.4,<2.6
-    django22: django-polymorphic>2.0
-    django30: django-mptt>0.9,<1.0
-    django30: easy-thumbnails>2.4,<2.9
-    django30: django-polymorphic>2.0
-    cms37: django-cms<=3.7,<3.8
+    django22: django~=2.2.0
+    django30: django~=3.0.0
+    django31: django~=3.1.0
+    cms37: django-cms>=3.7,<3.8
     cms37: djangocms-text-ckeditor>=3.6
     -r{toxinidir}/requirements-test.txt
 passenv =


### PR DESCRIPTION
# Description

No code change required, we only need to bump dependencies as they will become available

## References

Fix #196

# Checklist

* [X] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
