### PR TITLE
Remove support for aldryn-boilerplates

### DIFF
--- a/app_helper/default_settings.py
+++ b/app_helper/default_settings.py
@@ -54,13 +54,3 @@ def get_default_settings(CMS_APP, CMS_PROCESSORS, CMS_MIDDLEWARE, CMS_APP_STYLE,
         EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
         ASGI_APPLICATION="app_helper.asgi:application",
     )
-
-
-def get_boilerplates_settings():
-    return {
-        "STATICFILES_FINDERS": ["aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder"],
-        "TEMPLATE_LOADERS": ["aldryn_boilerplates.template_loaders.AppDirectoriesLoader"],
-        "TEMPLATE_CONTEXT_PROCESSORS": ["aldryn_boilerplates.context_processors.boilerplate"],
-        "ALDRYN_BOILERPLATE_NAME": "bootstrap3",
-        "INSTALLED_APPS": ["aldryn_boilerplates"],
-    }

--- a/app_helper/main.py
+++ b/app_helper/main.py
@@ -18,16 +18,16 @@ To use a different database, set the DATABASE_URL environment variable to a
 dj-database-url compatible value.
 
 Usage:
-    django-app-helper <application> test [--failfast] [--migrate] [--no-migrate] [<test-label>...] [--xvfb] [--runner=<test.runner.class>] [--extra-settings=</path/to/settings.py>] [--cms] [--runner-options=<option1>,<option2>] [--native] [--boilerplate] [--persistent] [--persistent-path=<path>] [--verbose=<level>]
-    django-app-helper <application> cms_check [--extra-settings=</path/to/settings.py>] [--cms] [--migrate] [--no-migrate] [--boilerplate]
-    django-app-helper <application> compilemessages [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
-    django-app-helper <application> makemessages [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--locale=locale]
-    django-app-helper <application> makemigrations [--extra-settings=</path/to/settings.py>] [--cms] [--merge] [--empty] [--dry-run] [--boilerplate] [<extra-applications>...]
-    django-app-helper <application> pyflakes [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
-    django-app-helper <application> authors [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
-    django-app-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--migrate] [--no-migrate] [--persistent | --persistent-path=<path>] [--verbose=<level>] [--use-daphne] [--use-channels]
-    django-app-helper <application> setup [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
-    django-app-helper <application> <command> [options] [--extra-settings=</path/to/settings.py>] [--cms] [--persistent] [--persistent-path=<path>] [--boilerplate] [--migrate] [--no-migrate]
+    django-app-helper <application> test [--failfast] [--migrate] [--no-migrate] [<test-label>...] [--xvfb] [--runner=<test.runner.class>] [--extra-settings=</path/to/settings.py>] [--cms] [--runner-options=<option1>,<option2>] [--native] [--persistent] [--persistent-path=<path>] [--verbose=<level>]
+    django-app-helper <application> cms_check [--extra-settings=</path/to/settings.py>] [--cms] [--migrate] [--no-migrate]
+    django-app-helper <application> compilemessages [--extra-settings=</path/to/settings.py>] [--cms]
+    django-app-helper <application> makemessages [--extra-settings=</path/to/settings.py>] [--cms] [--locale=locale]
+    django-app-helper <application> makemigrations [--extra-settings=</path/to/settings.py>] [--cms] [--merge] [--empty] [--dry-run] [<extra-applications>...]
+    django-app-helper <application> pyflakes [--extra-settings=</path/to/settings.py>] [--cms]
+    django-app-helper <application> authors [--extra-settings=</path/to/settings.py>] [--cms]
+    django-app-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--migrate] [--no-migrate] [--persistent | --persistent-path=<path>] [--verbose=<level>] [--use-daphne] [--use-channels]
+    django-app-helper <application> setup [--extra-settings=</path/to/settings.py>] [--cms]
+    django-app-helper <application> <command> [options] [--extra-settings=</path/to/settings.py>] [--cms] [--persistent] [--persistent-path=<path>] [--migrate] [--no-migrate]
 
 Options:
     -h --help                   Show this screen.
@@ -38,7 +38,6 @@ Options:
     --merge                     Merge migrations
     --failfast                  Stop tests on first failure.
     --native                    Use the native test command, instead of the django-app-helper on
-    --boilerplate               Add support for aldryn-boilerplates
     --persistent                Use persistent storage
     --persistent-path=<path>    Persistent storage path
     --locale=locale,-l=locale   Update messgaes for given locale

--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -132,13 +132,6 @@ def _reset_django(settings):
         clear_url_caches()
 
 
-def extend_settings(settings, extra_settings, key, insertion_point):
-    for item in extra_settings[key]:
-        if item not in settings[key]:
-            settings[key].insert(settings[key].index(insertion_point), item)
-    return settings
-
-
 def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):  # NOQA
     """
     Setup the Django settings

--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -151,7 +151,7 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):  # NOQ
     """
     import dj_database_url
 
-    from .default_settings import get_boilerplates_settings, get_default_settings
+    from .default_settings import get_default_settings
 
     try:
         extra_settings_file = args.get("--extra-settings")
@@ -235,34 +235,6 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):  # NOQ
         default_settings["INSTALLED_APPS"].append("mptt")
     if "filer" in default_settings["INSTALLED_APPS"] and "easy_thumbnails" not in default_settings["INSTALLED_APPS"]:
         default_settings["INSTALLED_APPS"].append("easy_thumbnails")
-
-    if args["--boilerplate"]:
-        boilerplate_settings = get_boilerplates_settings()
-
-        # Do not override helper settings with defaults.
-        if "ALDRYN_BOILERPLATE_NAME" in default_settings.keys():
-            del boilerplate_settings["ALDRYN_BOILERPLATE_NAME"]
-
-        default_settings = extend_settings(
-            default_settings,
-            boilerplate_settings,
-            "STATICFILES_FINDERS",
-            "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-        )
-        del boilerplate_settings["STATICFILES_FINDERS"]
-
-        default_settings = extend_settings(
-            default_settings,
-            boilerplate_settings,
-            "TEMPLATE_LOADERS",
-            "django.template.loaders.app_directories.Loader",
-        )
-        del boilerplate_settings["TEMPLATE_LOADERS"]
-
-        for setting in ("INSTALLED_APPS", "TEMPLATE_CONTEXT_PROCESSORS"):
-            default_settings[setting].extend(boilerplate_settings[setting])
-            del boilerplate_settings[setting]
-        default_settings.update(boilerplate_settings)
 
     default_settings["TEMPLATES"] = [
         {

--- a/changes/199.feature
+++ b/changes/199.feature
@@ -1,0 +1,1 @@
+Remove support for aldryn-boilerplates

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -74,7 +74,6 @@ Options
   directory is needed, use ``--persistent-path`` to provide the path;
 * ``--persistent-path``: persistent storage path, instead of ``data``
 * ``--no-migrate``: skip migrations;
-* ``--boilerplate``: adds ``aldryn-boilerplates`` configuration to settings;
 * ``--xvfb``: whether to configure ``xvfb`` (for frontend tests);
 * ``--native`` use the native Django command: the use of this option is **incompatible** with
   the options above.
@@ -201,7 +200,7 @@ server
 
 ::
 
-    django-app-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--migrate] [--no-migrate] [--persistent | --persistent-path=<path>] [--verbose=<level>] [--use-daphne] [--use-channels]
+    django-app-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--migrate] [--no-migrate] [--persistent | --persistent-path=<path>] [--verbose=<level>] [--use-daphne] [--use-channels]
 
 Starts a runserver instance.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ wheel
 pep517
 invoke
 tox>=1.8
-aldryn-boilerplates
 pyflakes<2.1
 pytest
 pytest-django

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -799,6 +799,7 @@ class CommandTests(unittest.TestCase):
             settings = runner.setup("example1", helper, use_cms=True, extra_args=["--cms"])
         self.assertTrue("example2" in settings.INSTALLED_APPS)
         self.assertTrue("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
+        self.assertTrue("sekizai" in settings.INSTALLED_APPS)
         self.assertTrue("cms" in settings.INSTALLED_APPS)
 
     def test_setup_custom_user(self):
@@ -815,6 +816,7 @@ class CommandTests(unittest.TestCase):
         self.assertTrue("example2" in settings.INSTALLED_APPS)
         self.assertTrue("custom_user" in settings.INSTALLED_APPS)
         self.assertTrue("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
+        self.assertTrue("sekizai" in settings.INSTALLED_APPS)
         self.assertTrue("cms" in settings.INSTALLED_APPS)
         del os.environ["AUTH_USER_MODEL"]
 
@@ -825,7 +827,7 @@ class CommandTests(unittest.TestCase):
 
             settings = runner.setup("example1", helper, extra_args=[])
         self.assertTrue("example2" in settings.INSTALLED_APPS)
-        self.assertFalse("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
+        self.assertFalse("sekizai" in settings.INSTALLED_APPS)
         self.assertFalse("cms" in settings.INSTALLED_APPS)
 
     def test_testrun_nocms(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,6 @@ import django
 from django.test.utils import setup_test_environment, teardown_test_environment
 
 from app_helper import runner
-from app_helper.default_settings import get_boilerplates_settings
 from app_helper.main import _make_settings, core
 from app_helper.utils import captured_output, get_user_model, temp_dir, work_in
 
@@ -54,7 +53,6 @@ DEFAULT_ARGS = {
     "--failfast": False,
     "--merge": False,
     "--locale": "",
-    "--boilerplate": False,
     "--dry-run": False,
     "--empty": False,
     "--native": False,
@@ -172,7 +170,6 @@ class CommandTests(unittest.TestCase):
         ]
         target_1 = {
             "--bind": "127.0.0.1",
-            "--boilerplate": False,
             "--cms": True,
             "--dry-run": False,
             "--empty": False,
@@ -227,7 +224,6 @@ class CommandTests(unittest.TestCase):
         ]
         target_2 = {
             "--bind": "127.0.0.1",
-            "--boilerplate": False,
             "--cms": True,
             "--dry-run": False,
             "--empty": False,
@@ -283,7 +279,6 @@ class CommandTests(unittest.TestCase):
         ]
         target_3 = {
             "--bind": "127.0.0.1",
-            "--boilerplate": False,
             "--cms": True,
             "--dry-run": False,
             "--empty": False,
@@ -353,7 +348,6 @@ class CommandTests(unittest.TestCase):
                         # Testing that helper.py in custom project is loaded
                         self.assertEqual(local_settings.TIME_ZONE, "Europe/Rome")
 
-                        args["--boilerplate"] = True
                         args["--extra-settings"] = "cms_helper_extra.py"
                         local_settings = _make_settings(args, self.application, settings, STATIC_ROOT, MEDIA_ROOT)
                         # Testing that helper.py in the command option is loaded
@@ -369,8 +363,6 @@ class CommandTests(unittest.TestCase):
                         )
                         self.assertEqual("top_middleware", local_settings.MIDDLEWARE[0])
                         self.assertTrue("some_middleware" in local_settings.MIDDLEWARE)
-
-                        boilerplate_settings = get_boilerplates_settings()
 
                         # Check the loaders
                         self.assertTrue(
@@ -393,25 +385,6 @@ class CommandTests(unittest.TestCase):
                         )
                         # Check template dirs
                         self.assertTrue("some/dir" in local_settings.TEMPLATES[0]["DIRS"])
-                        # Check for aldryn boilerplates
-                        for name, value in boilerplate_settings.items():
-                            if not name.startswith("TEMPLATE"):
-                                if type(value) in (list, tuple):
-                                    self.assertTrue(set(getattr(local_settings, name)).intersection(set(value)))
-                                elif name == "ALDRYN_BOILERPLATE_NAME":
-                                    self.assertEqual(getattr(local_settings, name), "legacy")
-                                else:
-                                    self.assertTrue(value in getattr(local_settings, name))
-                            elif name == "TEMPLATE_CONTEXT_PROCESSORS":
-                                self.assertTrue(
-                                    set(local_settings.TEMPLATES[0]["OPTIONS"]["context_processors"]).intersection(
-                                        set(value)
-                                    )
-                                )
-                            elif name == "TEMPLATE_LOADERS":
-                                self.assertTrue(
-                                    set(local_settings.TEMPLATES[0]["OPTIONS"]["loaders"]).intersection(set(value))
-                                )
 
     @patch("app_helper.server.autoreload.run_with_reloader")
     def test_server_django(self, run_with_reloader):
@@ -823,9 +796,9 @@ class CommandTests(unittest.TestCase):
         with captured_output():
             from tests.test_utils import helper
 
-            settings = runner.setup("example1", helper, use_cms=True, extra_args=["--boilerplate"])
+            settings = runner.setup("example1", helper, use_cms=True, extra_args=["--cms"])
         self.assertTrue("example2" in settings.INSTALLED_APPS)
-        self.assertTrue("aldryn_boilerplates" in settings.INSTALLED_APPS)
+        self.assertTrue("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
         self.assertTrue("cms" in settings.INSTALLED_APPS)
 
     def test_setup_custom_user(self):
@@ -838,10 +811,10 @@ class CommandTests(unittest.TestCase):
         with captured_output():
             from tests.test_utils import cms_helper_custom
 
-            settings = runner.setup("example1", cms_helper_custom, use_cms=True, extra_args=["--boilerplate"])
+            settings = runner.setup("example1", cms_helper_custom, use_cms=True, extra_args=["--cms"])
         self.assertTrue("example2" in settings.INSTALLED_APPS)
         self.assertTrue("custom_user" in settings.INSTALLED_APPS)
-        self.assertTrue("aldryn_boilerplates" in settings.INSTALLED_APPS)
+        self.assertTrue("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
         self.assertTrue("cms" in settings.INSTALLED_APPS)
         del os.environ["AUTH_USER_MODEL"]
 
@@ -852,7 +825,7 @@ class CommandTests(unittest.TestCase):
 
             settings = runner.setup("example1", helper, extra_args=[])
         self.assertTrue("example2" in settings.INSTALLED_APPS)
-        self.assertFalse("aldryn_boilerplates" in settings.INSTALLED_APPS)
+        self.assertFalse("djangocms_text_ckeditor" in settings.INSTALLED_APPS)
         self.assertFalse("cms" in settings.INSTALLED_APPS)
 
     def test_testrun_nocms(self):


### PR DESCRIPTION
# Description

aldryn-boilerplates is no longer active, no reason to keep its support

## References

Fix #199 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
