### PR TITLE
Add minimal Django 4.0 to let other packages use app-helper

### DIFF
--- a/app_helper/urls.py
+++ b/app_helper/urls.py
@@ -1,8 +1,9 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import re_path
 from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
@@ -11,21 +12,23 @@ from .utils import load_from_file
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT, "show_indexes": True}),  # NOQA
-    url(r"^jsi18n/(?P<packages>\S+?)/$", JavaScriptCatalog.as_view()),  # NOQA
+    re_path(r"^media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT, "show_indexes": True}),  # NOQA
+    re_path(r"^jsi18n/(?P<packages>\S+?)/$", JavaScriptCatalog.as_view()),  # NOQA
 ]
 i18n_urls = [
-    url(r"^admin/", admin.site.urls),
+    re_path(r"^admin/", admin.site.urls),
 ]
 
 try:
     load_from_file("%s.urls" % settings.BASE_APPLICATION)
-    i18n_urls.append(url(r"^%s/" % settings.BASE_APPLICATION, include("%s.urls" % settings.BASE_APPLICATION)))  # NOQA
+    i18n_urls.append(
+        re_path(r"^%s/" % settings.BASE_APPLICATION, include("%s.urls" % settings.BASE_APPLICATION))
+    )  # NOQA
 except OSError:  # pragma: no cover
     pass
 
 if settings.USE_CMS:
-    i18n_urls.append(url(r"^", include("cms.urls")))  # NOQA
+    i18n_urls.append(re_path(r"^", include("cms.urls")))  # NOQA
 
 urlpatterns += i18n_patterns(*i18n_urls)
 urlpatterns += staticfiles_urlpatterns()

--- a/changes/208.feature
+++ b/changes/208.feature
@@ -1,0 +1,1 @@
+Add minimal django 4.0 support

--- a/tests/test_utils/example1/cms_apps.py
+++ b/tests/test_utils/example1/cms_apps.py
@@ -1,6 +1,6 @@
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Example(CMSApp):

--- a/tests/test_utils/example1/models.py
+++ b/tests/test_utils/example1/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ExampleModel1(models.Model):

--- a/tests/test_utils/example2/models.py
+++ b/tests/test_utils/example2/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ExampleModel2(models.Model):

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,18 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{310}-django{32}-{cms311,cms310,nocms,async}
+    py{310}-django{41,40,32}-{cms311,cms310,nocms,async}
     py{39,38,37}-django{32}-{cms311,cms310,cms39,nocms,async}
     py{39,38,37}-django{22}-{cms311,cms310,cms39,cms38,cms37,nocms,async}
-minversion = 3.22
+minversion = 3.23
 
 [testenv]
 commands = {env:COMMAND:python} helper.py {posargs}
 deps=
     django22: django~=2.2.0
     django32: django~=3.2.0
+    django40: django~=4.0.0
+    django41: django~=4.1rc1
     cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
     cms37: djangocms-text-ckeditor
     cms38: https://github.com/divio/django-cms/archive/release/3.8.x.zip


### PR DESCRIPTION
# Description

This first step only removes django 4.0 issues in app-helper codebase, as app-helper uses other packages to provide the full feature set, we must wait for external packages to catch on before providing full django 4.0 compatibility

## References

- #208 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
