### PR TITLE
Fix runner-options argument on Django test runner

### DIFF
--- a/app_helper/main.py
+++ b/app_helper/main.py
@@ -84,6 +84,8 @@ def _test_run_worker(test_labels, test_runner, failfast=False, runner_options=No
         if "PytestTestRunner" in test_runner:
             kwargs["pytest_args"] = runner_options
         else:
+            if not isinstance(runner_options, list):
+                runner_options = runner_options.split(" ")
             extra = _parse_runner_options(TestRunner, runner_options)
             extra.update(kwargs)
             kwargs = extra

--- a/app_helper/server.py
+++ b/app_helper/server.py
@@ -48,6 +48,7 @@ def _init_runserver(runserver_module, bind, port, verbose, logger=None, channels
             "use_static_handler": True,
             "use_threading": True,
             "verbosity": verbose,
+            "skip_checks": True,
             "use_reloader": True,
         },
     )

--- a/changes/220.bugfix
+++ b/changes/220.bugfix
@@ -1,0 +1,1 @@
+Fix runner-options argument on Django test runner

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -604,7 +604,7 @@ class CommandTests(unittest.TestCase):
                     args["--persistent"] = True
                     args["--runner"] = "runners.CapturedOutputRunner"
                     args["<test-label>"] = self.application
-                    args["--runner-options"] = ["--tag=a-tag"]
+                    args["--runner-options"] = "--tag=a-tag"
                     core(args, self.application)
             self.assertTrue("Ran 1 test in" in err.getvalue())
             self.assertEqual(exit_state.exception.code, 0)


### PR DESCRIPTION
# Description

runner options argument must be converted to string before passing it to Django test runner

## References

Fix #220 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
