### PR TITLE
As of django-filer 3.0 mptt is not needed as a dependency #224 

### DIFF
--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -238,7 +238,10 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):  # NOQ
         if "treebeard" not in default_settings["INSTALLED_APPS"]:
             default_settings["INSTALLED_APPS"].append("treebeard")
     if "filer" in default_settings["INSTALLED_APPS"] and "mptt" not in default_settings["INSTALLED_APPS"]:
-        default_settings["INSTALLED_APPS"].append("mptt")
+        from filer import __version__
+        if __version__ < "3":
+            # As of django-filer 3.0 mptt is not needed as a dependency
+            default_settings["INSTALLED_APPS"].append("mptt")
     if "filer" in default_settings["INSTALLED_APPS"] and "easy_thumbnails" not in default_settings["INSTALLED_APPS"]:
         default_settings["INSTALLED_APPS"].append("easy_thumbnails")
 

--- a/app_helper/utils.py
+++ b/app_helper/utils.py
@@ -239,6 +239,7 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):  # NOQ
             default_settings["INSTALLED_APPS"].append("treebeard")
     if "filer" in default_settings["INSTALLED_APPS"] and "mptt" not in default_settings["INSTALLED_APPS"]:
         from filer import __version__
+
         if __version__ < "3":
             # As of django-filer 3.0 mptt is not needed as a dependency
             default_settings["INSTALLED_APPS"].append("mptt")

--- a/changes/225.bugfix
+++ b/changes/225.bugfix
@@ -1,0 +1,1 @@
+Do not add mptt with django-filer 3+


### PR DESCRIPTION
# Description

Describe:

* This PR only automatically adds `mptt` to `INSTALLED_APPS` for django-filer, if the installed version of django-filer is below 3.0. 
* django-filer as of version 3.0 does not depend on `mptt` any more.
* Without this change, a `ModuleNotFound` exception will be raised in an environment without `mptt`

## References

Fix #225 

Fix #224 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
