### PR TITLE
Add DjangoCMS 3.11 to Django 5.0 test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
         continue-on-error: [false]
         exclude:
           - django: 50
-            cms: cms311
-          - django: 50
             python-version: 3.9
           - django: 50
             python-version: 3.8

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,6 @@ Django App helper
 
     Starting from 3 django-app-helper only supports Django 2.2+ and django CMS 3.7+. If you need support for older (unsupported) versions, use django-app-helper 2.
 
-    Django 5.0 support exclude django CMS 3.11 support, as django CMS 3.11 doesn't yet support Django 5.0.
-
 ******************************************
 Helper for django applications development
 ******************************************

--- a/changes/252.feature
+++ b/changes/252.feature
@@ -1,0 +1,1 @@
+Add DjangoCMS 3.11 to Django 5.0 test matrix

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{3.12}-django{42,50}-{nocms,async}
-    py{3.11}-django{42,41,40,32}-{cms311,nocms,async}
-    py{3.10}-django{42,41,40,32}-{cms311,nocms,async}
+    py{3.12}-django{50,42}-{cms311,nocms,async}
+    py{3.11}-django{50,42,41,40,32}-{cms311,nocms,async}
+    py{3.10}-django{50,42,41,40,32}-{cms311,nocms,async}
     py{3.9}-django{32}-{cms311,nocms,async}
     py{3.8}-django{32}-{cms311,nocms,async}
 minversion = 3.23
@@ -22,8 +22,8 @@ deps=
     django40: django~=4.0.0
     django41: django~=4.1.0
     django42: django~=4.2.0
-    django50: django~=5.0.0b1
-    cms311: https://github.com/yakky/django-cms/archive/release/3.11.x.zip
+    django50: django~=5.0.0
+    cms311: https://github.com/django-cms/django-cms/archive/develop.zip
     cms311: djangocms-text-ckeditor>=5.0,<6.0
     -r{toxinidir}/requirements-test.txt
     async: channels[daphne]~=4.0.0


### PR DESCRIPTION
# Description

Add DjangoCMS 3.11 to Django 5.0 test matrix

## References

Fix #252 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
