### PR TITLE
Add headers argument to RequestTestCaseMixin.request method

### DIFF
--- a/app_helper/base_test.py
+++ b/app_helper/base_test.py
@@ -109,6 +109,7 @@ class RequestTestCaseMixin:
         use_middlewares=False,
         secure=False,
         use_toolbar=False,
+        headers=None,
     ):
         """
         Create a request for the given parameters.
@@ -138,10 +139,12 @@ class RequestTestCaseMixin:
         :param secure: create HTTPS request
         :type secure: bool
         :param use_toolbar: add django CMS toolbar
-        :type secure: bool
+        :type use_toolbar: bool
+        :param headers: additional headers
+        :type headers: dict
         :return: request
         """
-        request = getattr(RequestFactory(), method)(path, data=data, secure=secure)
+        request = getattr(RequestFactory(), method)(path, data=data, secure=secure, headers=headers)
         return self._prepare_request(
             request,
             page,

--- a/changes/290.feature
+++ b/changes/290.feature
@@ -1,0 +1,1 @@
+Add headers argument to RequestTestCaseMixin.request method


### PR DESCRIPTION
# Description

RequestTestCaseMixin.request now accepts headers dict and pass it to RequestFactory

## References

Fix #290

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
